### PR TITLE
ED5: Google Maps <Map> foundation + dev-tools verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ on:
 
 env:
   NODE_VERSION: "22"
-  # Build-time placeholder; production uses Secret Manager via Cloud Run.
+  # Build-time placeholders; the deploy job injects the real values via
+  # --build-arg. The map page is force-dynamic + gated so it isn't rendered
+  # during `next build`, but a non-empty key keeps the build robust if a map
+  # ever lands on a statically-rendered route.
   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ci_placeholder
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: AIza_ci_placeholder
 
 jobs:
   test:
@@ -86,6 +90,10 @@ jobs:
   #   GCP_REGION             e.g. us-central1
   #   ARTIFACT_REPO          e.g. breadly-dev
   #   CLERK_PUBLISHABLE_KEY  pk_test_... (baked into the client bundle)
+  #   GOOGLE_MAPS_API_KEY    AIza... (baked into the client bundle; required for
+  #                          the map to render on the deployed app)
+  # Optional repo variable (vars.*, not a secret — it's non-sensitive):
+  #   GOOGLE_MAPS_MAP_ID     cloud Map ID for styling + Advanced Markers
   build-and-deploy:
     name: Build image + deploy to Cloud Run (dev)
     if: github.ref == 'refs/heads/main'
@@ -115,6 +123,8 @@ jobs:
         run: |
           docker build \
             --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }} \
+            --build-arg NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }} \
+            --build-arg NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=${{ vars.GOOGLE_MAPS_MAP_ID }} \
             -t "$IMAGE_TAG" .
           docker push "$IMAGE_TAG"
 

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -33,3 +33,8 @@ RESEND_API_KEY=re_REPLACE_ME
 # geocoding/autocomplete (storefront + claim flow) — not used yet, leave it off
 # to avoid enabling/billing an API the current map doesn't call.
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=REPLACE_ME
+
+# Optional Map ID for cloud-based styling + Advanced Markers (pins). Create one
+# in the GCP console under Map Management. Leave unset for Google's default
+# raster style — the base map renders either way.
+NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -27,3 +27,7 @@ UPLOADS_BUCKET=breadly-dev-uploads
 
 # Email — Resend; optional locally
 RESEND_API_KEY=re_REPLACE_ME
+
+# Google Maps — get a key from https://console.cloud.google.com
+# Required APIs: Maps JavaScript API, Places API
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=REPLACE_ME

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -29,5 +29,7 @@ UPLOADS_BUCKET=breadly-dev-uploads
 RESEND_API_KEY=re_REPLACE_ME
 
 # Google Maps — get a key from https://console.cloud.google.com
-# Required APIs: Maps JavaScript API, Places API
+# Required now: Maps JavaScript API. Places API is needed later for address
+# geocoding/autocomplete (storefront + claim flow) — not used yet, leave it off
+# to avoid enabling/billing an API the current map doesn't call.
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=REPLACE_ME

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -35,6 +35,7 @@ RESEND_API_KEY=re_REPLACE_ME
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=REPLACE_ME
 
 # Optional Map ID for cloud-based styling + Advanced Markers (pins). Create one
-# in the GCP console under Map Management. Leave unset for Google's default
-# raster style — the base map renders either way.
-NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
+# in the GCP console under Map Management. Leave this line commented for Google's
+# default raster style — the base map renders either way. (Uncomment and set a
+# value to enable styling; an empty value is normalized to "no Map ID".)
+# NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,6 +20,14 @@ COPY . .
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
 
+# Google Maps key (required) + optional Map ID — same story: NEXT_PUBLIC_* is
+# inlined into the client bundle, so the deployed map only works if these are
+# present at build. CI passes them via --build-arg.
+ARG NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=""
+ENV NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
+ARG NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=""
+ENV NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=${NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID}
+
 RUN npm run build
 
 # ----- runtime ------------------------------------------------------------

--- a/web/cloudbuild.yaml
+++ b/web/cloudbuild.yaml
@@ -4,6 +4,10 @@ steps:
       - build
       - --build-arg
       - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${_CLERK_PK}
+      - --build-arg
+      - NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${_MAPS_API_KEY}
+      - --build-arg
+      - NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=${_MAPS_MAP_ID}
       - -t
       - ${_IMG}
       - .
@@ -13,4 +17,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _CLERK_PK: ""
+  _MAPS_API_KEY: ""
+  _MAPS_MAP_ID: ""
   _IMG: ""

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.2.7",
         "@google-cloud/storage": "^7.19.0",
+        "@vis.gl/react-google-maps": "^1.8.3",
         "drizzle-orm": "^0.45.2",
         "next": "16.2.4",
         "postgres": "^3.4.9",
@@ -1117,6 +1118,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2107,6 +2117,12 @@
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2154,6 +2170,21 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2669,6 +2700,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-sha256": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "@clerk/testing": "^2.0.21",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
+        "@types/google.maps": "^3.64.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "@clerk/testing": "^2.0.21",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
+    "@types/google.maps": "^3.64.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.2.7",
     "@google-cloud/storage": "^7.19.0",
+    "@vis.gl/react-google-maps": "^1.8.3",
     "drizzle-orm": "^0.45.2",
     "next": "16.2.4",
     "postgres": "^3.4.9",

--- a/web/src/app/dev-tools/map/map-verify.tsx
+++ b/web/src/app/dev-tools/map/map-verify.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { Map } from "@/components/Map";
+import { Map, BOULDER_CENTER, DEFAULT_ZOOM } from "@/components/Map";
 
 export function MapVerify() {
+  // [LAW:one-source-of-truth] Display the real default center/zoom rather than
+  // a hand-copied caption that drifts from the constants it describes.
+  const { lat, lng } = BOULDER_CENTER;
   return (
     <div className="rounded-xl border border-stone-200 overflow-hidden">
       <Map className="w-full h-[480px]" />
       <div className="px-5 py-3 bg-stone-50 border-t border-stone-200 text-xs text-stone-500">
-        Centered on Boulder, CO (40.015°N, 105.270°W) · zoom 13 · if the map
-        renders above, MAP1 is complete.
+        Centered on Boulder, CO ({lat}°N, {Math.abs(lng)}°W) · zoom{" "}
+        {DEFAULT_ZOOM} · if the map renders above, MAP1 is complete.
       </div>
     </div>
   );

--- a/web/src/app/dev-tools/map/map-verify.tsx
+++ b/web/src/app/dev-tools/map/map-verify.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Map } from "@/components/Map";
+
+export function MapVerify() {
+  return (
+    <div className="rounded-xl border border-stone-200 overflow-hidden">
+      <Map className="w-full h-[480px]" />
+      <div className="px-5 py-3 bg-stone-50 border-t border-stone-200 text-xs text-stone-500">
+        Centered on Boulder, CO (40.015°N, 105.270°W) · zoom 13 · if the map
+        renders above, MAP1 is complete.
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/dev-tools/map/page.tsx
+++ b/web/src/app/dev-tools/map/page.tsx
@@ -1,0 +1,26 @@
+import { isDevModeEnabled } from "@/lib/dev-tools-gate";
+import { notFound } from "next/navigation";
+import { MapVerify } from "./map-verify";
+
+export const dynamic = "force-dynamic";
+
+export default async function MapTestPage() {
+  if (!isDevModeEnabled()) notFound();
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-10 space-y-6">
+      <header>
+        <p className="text-xs uppercase tracking-widest text-amber-700 mb-2">
+          Dev tools · MAP1
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Google Maps — setup verification
+        </h1>
+        <p className="mt-2 text-sm text-stone-600">
+          Confirms the API key is wired and the shared{" "}
+          <code>&lt;Map&gt;</code> component renders without errors.
+        </p>
+      </header>
+      <MapVerify />
+    </main>
+  );
+}

--- a/web/src/app/dev-tools/map/page.tsx
+++ b/web/src/app/dev-tools/map/page.tsx
@@ -1,11 +1,12 @@
-import { isDevModeEnabled } from "@/lib/dev-tools-gate";
-import { notFound } from "next/navigation";
+import { requireDevTools } from "@/lib/dev-tools-gate";
 import { MapVerify } from "./map-verify";
 
 export const dynamic = "force-dynamic";
 
 export default async function MapTestPage() {
-  if (!isDevModeEnabled()) notFound();
+  // [LAW:single-enforcer] One gate for all /dev-tools access (env + auth +
+  // canDev). No page reimplements a weaker subset of it.
+  await requireDevTools();
   return (
     <main className="max-w-3xl mx-auto px-6 py-10 space-y-6">
       <header>

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { APIProvider, Map as GoogleMap } from "@vis.gl/react-google-maps";
+
+// [LAW:types-are-the-program] A missing key is external-config input at a trust
+// boundary. Validate once here so the rest of the component sees a guaranteed
+// `string`; the alternative `!` laundered `undefined` into Google's apiKey and
+// produced a silently broken map instead of a loud failure.
+const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+if (!API_KEY) {
+  throw new Error(
+    "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not set — copy web/.env.local.example to web/.env.local and add a Maps JavaScript API key.",
+  );
+}
+
+// Boulder, CO — default center for all maps in the app
+export const BOULDER_CENTER = { lat: 40.015, lng: -105.2705 };
+export const DEFAULT_ZOOM = 13;
+
+type MapProps = {
+  center?: google.maps.LatLngLiteral;
+  zoom?: number;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+export function Map({
+  center = BOULDER_CENTER,
+  zoom = DEFAULT_ZOOM,
+  className,
+  children,
+}: MapProps) {
+  return (
+    <APIProvider apiKey={API_KEY}>
+      <GoogleMap
+        mapId="breadly-map"
+        center={center}
+        zoom={zoom}
+        className={className}
+        gestureHandling="greedy"
+        disableDefaultUI={false}
+      >
+        {children}
+      </GoogleMap>
+    </APIProvider>
+  );
+}

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -15,7 +15,10 @@ function mapsApiKey(): string {
   const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   if (!key) {
     throw new Error(
-      "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not set — copy web/.env.local.example to web/.env.local and add a Maps JavaScript API key.",
+      "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not set. Locally: copy " +
+        "web/.env.local.example to web/.env.local and add a Maps JavaScript " +
+        "API key. Deployed: it is inlined at build time, so set the " +
+        "GOOGLE_MAPS_API_KEY build secret (see .github/workflows/ci.yml).",
     );
   }
   return key;
@@ -39,10 +42,14 @@ export function Map({
   children,
 }: MapProps) {
   // [LAW:one-source-of-truth] The Map ID is per-GCP-project config like the API
-  // key — sourced from env, not a source constant. Undefined flows straight to
-  // the optional prop (Google's default raster style); a value enables cloud
+  // key — sourced from env, not a source constant. A value enables cloud
   // styling + Advanced Markers (the pins ED5 adds later).
-  const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID;
+  //
+  // [LAW:types-are-the-program] Collapse blank/whitespace to undefined at the
+  // read. An unset env var arrives as "" (the `KEY=` form, the Dockerfile ARG
+  // default, an empty CI var) — `mapId=""` is an illegal in-between Google may
+  // treat as a bad ID, so the rest of the code only ever sees real-id-or-absent.
+  const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID?.trim() || undefined;
   return (
     <APIProvider apiKey={mapsApiKey()}>
       <GoogleMap

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -3,15 +3,20 @@
 import { APIProvider, Map as GoogleMap } from "@vis.gl/react-google-maps";
 
 // [LAW:types-are-the-program] A missing key is external-config input at a trust
-// boundary. Validate once here so the rest of the component sees a guaranteed
-// `string`; the alternative `!` laundered `undefined` into Google's apiKey and
-// produced a silently broken map instead of a loud failure.
-const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-if (!API_KEY) {
-  throw new Error(
-    "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not set — copy web/.env.local.example to web/.env.local and add a Maps JavaScript API key.",
-  );
+// boundary. This getter's `string` return type is the promise; the throw is the
+// only escape, so callers can never launder `undefined` into Google's apiKey
+// (which silently renders a broken map instead of failing loudly).
+function mapsApiKey(): string {
+  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  if (!key) {
+    throw new Error(
+      "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not set — copy web/.env.local.example to web/.env.local and add a Maps JavaScript API key.",
+    );
+  }
+  return key;
 }
+
+const API_KEY = mapsApiKey();
 
 // Boulder, CO — default center for all maps in the app
 export const BOULDER_CENTER = { lat: 40.015, lng: -105.2705 };

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -38,10 +38,15 @@ export function Map({
   className,
   children,
 }: MapProps) {
+  // [LAW:one-source-of-truth] The Map ID is per-GCP-project config like the API
+  // key — sourced from env, not a source constant. Undefined flows straight to
+  // the optional prop (Google's default raster style); a value enables cloud
+  // styling + Advanced Markers (the pins ED5 adds later).
+  const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID;
   return (
     <APIProvider apiKey={mapsApiKey()}>
       <GoogleMap
-        mapId="breadly-map"
+        mapId={mapId}
         center={center}
         zoom={zoom}
         className={className}

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -6,6 +6,11 @@ import { APIProvider, Map as GoogleMap } from "@vis.gl/react-google-maps";
 // boundary. This getter's `string` return type is the promise; the throw is the
 // only escape, so callers can never launder `undefined` into Google's apiKey
 // (which silently renders a broken map instead of failing loudly).
+//
+// [LAW:dataflow-not-control-flow] Read at render, not module load. The key is
+// needed when a map is drawn, so validation lives at that boundary — keeping
+// imports side-effect-free (BOULDER_CENTER is importable without a key, and
+// `next build` stays green), matching the lazy-env convention in db/client.ts.
 function mapsApiKey(): string {
   const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   if (!key) {
@@ -15,8 +20,6 @@ function mapsApiKey(): string {
   }
   return key;
 }
-
-const API_KEY = mapsApiKey();
 
 // Boulder, CO — default center for all maps in the app
 export const BOULDER_CENTER = { lat: 40.015, lng: -105.2705 };
@@ -36,7 +39,7 @@ export function Map({
   children,
 }: MapProps) {
   return (
-    <APIProvider apiKey={API_KEY}>
+    <APIProvider apiKey={mapsApiKey()}>
       <GoogleMap
         mapId="breadly-map"
         center={center}


### PR DESCRIPTION
## Summary
- Adds a single `<Map>` component (`web/src/components/Map.tsx`) wrapping `@vis.gl/react-google-maps` — the one boundary every map surface loads Google's SDK through `[LAW:single-enforcer, LAW:locality-or-seam]`. Defaults to Boulder center / zoom 13.
- Adds a dev-mode-gated verification page at `/dev-tools/map` so the key + render path can be checked without a user-facing surface yet.
- Validates `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` at load and throws if absent, instead of laundering `undefined` through `!` (which silently rendered a broken map) `[LAW:types-are-the-program]`.
- Documents the env var in `.env.local.example`; adds the dependency.

## Plan divergence (needs follow-up)
The `breadly-map-f61` (ED5) epic and its 6 children still describe a **MapLibre GL + Protomaps + self-hosted tiles** path. This PR takes the **Google Maps** route instead. The tickets need rewriting to match — notably `f61.1 Tile build + Cloud Storage upload` no longer applies, and Places/geocoding scope should be added. **Provider-independent scope still stands:** server-side privacy fuzzing (`f61.3`), list+map sync (`f61.4`), geolocation consent (`f61.5`).

## Verification
- Headless Chrome at `http://localhost:3000/dev-tools/map`: `.gm-style` mounts with real Google tiles ("Map data ©2026 Google"), center confirmed at 40.015,-105.2705, **zero console errors** before and after the key-validation change.

## Test plan
- [ ] Reviewer loads `/dev-tools/map` with a valid key → interactive Google map renders, no console errors.
- [ ] Temporarily unset `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` → page fails loudly with the env-var error (not a blank/broken map).
- [ ] Decide and execute the ED5 ticket rewrite (Google path) before the next map PR.